### PR TITLE
Update issues found in NVIDIA Transformer data processing scripts and make better instructions in README for data processing.

### DIFF
--- a/NVIDIA/benchmarks/transformer/implementations/pytorch/README.md
+++ b/NVIDIA/benchmarks/transformer/implementations/pytorch/README.md
@@ -10,10 +10,15 @@ This problem uses Attention mechanisms to do language translation.
 
 ### Steps to download and verify data
 
-Downloading and preprocessing the data is handled inside submission scripts. To do this manually run 
-    bash run_preprocessing.sh && bash run_conversion.sh
-    
-The raw downloaded data is stored in /raw_data and preprocessed data is stored in /workspace/translation/examples/translation/wmt14_en_de. Your external DATADIR path can be mounted to this location to be used in the following steps. The vocabulary file provided by the MLPerf v0.6 transformer reference is stored inside of the container at /workspace/translation/reference_dictionary.ende.txt.
+Steps to download, tokenize, and convert the reference tokenization to the proper pytorch file format:
+
+```
+docker build --pull -t mlperf-nvidia:translation .
+mkdir -p $DATADIR/raw_data
+docker  run --rm -it  -u $(id -u):$(id -g)  -v $DATADIR:/workspace/translation/examples/translation/wmt14_en_de -v $DATADIR/raw_data:/raw_data mlperf-nvidia:translation
+bash run_preprocessing.sh
+bash run_conversion.sh
+```
 
 ### Steps to run and time
 

--- a/NVIDIA/benchmarks/transformer/implementations/pytorch/README.md
+++ b/NVIDIA/benchmarks/transformer/implementations/pytorch/README.md
@@ -10,7 +10,7 @@ This problem uses Attention mechanisms to do language translation.
 
 ### Steps to download and verify data
 
-Steps to download, tokenize, and convert the reference tokenization to the proper pytorch file format:
+Steps to download the dataset, tokenize it, and convert the reference tokenization to the proper pytorch file format:
 
 ```
 docker build --pull -t mlperf-nvidia:translation .

--- a/NVIDIA/benchmarks/transformer/implementations/pytorch/preprocess.py
+++ b/NVIDIA/benchmarks/transformer/implementations/pytorch/preprocess.py
@@ -28,7 +28,7 @@ import urllib
 import six
 import urllib.request
 
-from mlperf_log_utils import mlperf_print, mlperf_submission_log, set_seeds, get_rank
+from mlperf_log_utils import mlperf_print, mlperf_submission_log
 
 from utils import tokenizer
 
@@ -464,8 +464,6 @@ def main(unused_argv):
 
 
 if __name__ == "__main__":
-
-  mlperf_log.ROOT_DIR_TRANSFORMER = os.path.dirname(os.path.realpath(__file__))
 
   parser = argparse.ArgumentParser()
   parser.add_argument(

--- a/NVIDIA/benchmarks/transformer/implementations/pytorch/run_preprocessing.sh
+++ b/NVIDIA/benchmarks/transformer/implementations/pytorch/run_preprocessing.sh
@@ -24,8 +24,7 @@ sed -i "1s/^/\'<lua_index_compat>\'\n/" /workspace/translation/examples/translat
 cp /workspace/translation/reference_dictionary.ende.txt /workspace/translation/examples/translation/wmt14_en_de/utf8/dict.en.txt
 cp /workspace/translation/reference_dictionary.ende.txt /workspace/translation/examples/translation/wmt14_en_de/utf8/dict.de.txt
 
-wget https://raw.githubusercontent.com/tensorflow/models/master/official/transformer/test_data/newstest2014.en -O /workspace/translation/examples/translation/wmt14_en_de/newstest2014.en
-wget https://raw.githubusercontent.com/tensorflow/models/master/official/transformer/test_data/newstest2014.de -O /workspace/translation/examples/translation/wmt14_en_de/newstest2014.de
+(cd /workspace/translation/examples/translation/wmt14_en_de && wget https://storage.googleapis.com/tf-perf-public/official_transformer/test_data/newstest2014.tgz && tar -xzvf newstest2014.tgz)
 
 python3 preprocess.py --raw_dir /raw_data/ --data_dir /workspace/translation/examples/translation/wmt14_en_de
 

--- a/NVIDIA/benchmarks/transformer/implementations/pytorch/utils/tokenizer.py
+++ b/NVIDIA/benchmarks/transformer/implementations/pytorch/utils/tokenizer.py
@@ -28,7 +28,7 @@ import numpy as np
 import six
 from six.moves import xrange  # pylint: disable=redefined-builtin
 
-from mlperf_log_utils import mlperf_print, mlperf_submission_log, set_seeds, get_rank
+from mlperf_log_utils import mlperf_print, mlperf_submission_log
 
 LUA = "<lua_index_compat>"
 PAD = "<pad>_"


### PR DESCRIPTION
1. The Transformer data processing scripts had logging imports that did not really exist and caused errors for users attempting to use the scripts. 
1. Updated the download path for the test dataset as the original path disappeared
1. Made explicit instructions in the README.md on how to execute dataset downloading, tokenization, and conversion to the file format needed by pytorch.


